### PR TITLE
style(index) disabling irc link for mobile media query

### DIFF
--- a/_sass/_helm.scss
+++ b/_sass/_helm.scss
@@ -533,6 +533,9 @@ a.button, button {
   }
 
   &.-irc {
+    @media only screen and (max-device-width: $mobile-maximum-width) {
+      display: none;
+    }
     background-color: $yellow;
 
     &:hover {


### PR DESCRIPTION
iOS/Safari at least, and I'd expect most mobile browser implementations, doesn't do anything with a `irc://`-prefixed hyperlink.